### PR TITLE
Add extended mouse behaviour support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -123,12 +123,12 @@ class NDPreferences(AddonPreferences):
     )
 
     enable_mouse_values: BoolProperty(
-        name="Enable Mouse Values",
+        name="Enable Mouse Values (move mouse to change values)",
         default=True,
     )
 
     extend_mouse_values: BoolProperty(
-        name="Extend Mouse Values (scroll wheel override for certain operations such as bevels)",
+        name="Extend Mouse Values (scroll wheel override)",
         default=True,
     )
 

--- a/__init__.py
+++ b/__init__.py
@@ -127,6 +127,11 @@ class NDPreferences(AddonPreferences):
         default=True,
     )
 
+    extend_mouse_values: BoolProperty(
+        name="Extend Mouse Values (scroll wheel override for certain operations such as bevels)",
+        default=True,
+    )
+
     use_fast_booleans: BoolProperty(
         name="Use Fast Booleans",
         default=True,
@@ -506,6 +511,7 @@ class NDPreferences(AddonPreferences):
         ui_prefs = [
             ["overlay_dpi"],
             ["enable_mouse_values"],
+            ["extend_mouse_values"],
             ["mouse_value_scalar"],
             ["mouse_value_steps"],
             ["unit_increment_size"],

--- a/bevels/bevel.py
+++ b/bevels/bevel.py
@@ -112,7 +112,10 @@ SHIFT — Create a stacked bevel modifier"""
             self.summon_old_operator(context)
 
         if self.key_step_up:
-            if no_stream(self.segments_input_stream) and self.key_alt:
+            if self.extend_mouse_values and no_stream(self.segments_input_stream) and self.key_no_modifiers:
+                self.segments = 2 if self.segments == 1 else self.segments + segment_factor
+                self.dirty = True
+            elif no_stream(self.segments_input_stream) and self.key_alt:
                 self.segments = 2 if self.segments == 1 else self.segments + segment_factor
                 self.dirty = True
             elif no_stream(self.profile_input_stream) and self.key_ctrl:
@@ -126,7 +129,10 @@ SHIFT — Create a stacked bevel modifier"""
                 self.dirty = True
 
         if self.key_step_down:
-            if no_stream(self.segments_input_stream) and self.key_alt:
+            if self.extend_mouse_values and no_stream(self.segments_input_stream) and self.key_no_modifiers:
+                self.segments = max(1, self.segments - segment_factor)
+                self.dirty = True
+            elif no_stream(self.segments_input_stream) and self.key_alt:
                 self.segments = max(1, self.segments - segment_factor)
                 self.dirty = True
             elif no_stream(self.profile_input_stream) and self.key_ctrl:
@@ -189,6 +195,8 @@ SHIFT — Create a stacked bevel modifier"""
 
         self.stacked = event.shift
         self.dirty = False
+
+        self.extend_mouse_values = get_preferences().enable_mouse_values and get_preferences().extend_mouse_values
 
         self.segments = 1
         self.width = 0
@@ -342,7 +350,7 @@ def draw_text_callback(self):
     draw_property(
         self,
         "Segments: {}".format(self.segments),
-        self.generate_key_hint("Alt", self.generate_step_hint(2, 1)),
+        self.generate_key_hint("Alt / Scroll" if self.extend_mouse_values else "Alt", self.generate_step_hint(2, 1)),
         active=self.key_alt,
         alt_mode=self.key_shift_alt,
         mouse_value=True,

--- a/bevels/bevel.py
+++ b/bevels/bevel.py
@@ -196,8 +196,6 @@ SHIFT — Create a stacked bevel modifier"""
         self.stacked = event.shift
         self.dirty = False
 
-        self.extend_mouse_values = get_preferences().enable_mouse_values and get_preferences().extend_mouse_values
-
         self.segments = 1
         self.width = 0
         self.profile = 0.5

--- a/bevels/edge_bevel.py
+++ b/bevels/edge_bevel.py
@@ -107,7 +107,10 @@ CTRL — Remove existing modifiers"""
             self.target_object.show_in_front = not self.target_object.show_in_front
 
         if self.key_step_up:
-            if no_stream(self.segments_input_stream) and self.key_alt:
+            if self.extend_mouse_values and no_stream(self.segments_input_stream) and self.key_no_modifiers:
+                self.segments = 2 if self.segments == 1 else self.segments + segment_factor
+                self.dirty = True
+            elif no_stream(self.segments_input_stream) and self.key_alt:
                 self.segments = 2 if self.segments == 1 else self.segments + segment_factor
                 self.dirty = True
             elif no_stream(self.profile_input_stream) and self.key_ctrl:
@@ -121,7 +124,10 @@ CTRL — Remove existing modifiers"""
                 self.dirty = True
 
         if self.key_step_down:
-            if no_stream(self.segments_input_stream) and self.key_alt:
+            if self.extend_mouse_values and no_stream(self.segments_input_stream) and self.key_no_modifiers:
+                self.segments = max(1, self.segments - segment_factor)
+                self.dirty = True
+            elif no_stream(self.segments_input_stream) and self.key_alt:
                 self.segments = max(1, self.segments - segment_factor)
                 self.dirty = True
             elif no_stream(self.profile_input_stream) and self.key_ctrl:
@@ -184,6 +190,8 @@ CTRL — Remove existing modifiers"""
 
         self.dirty = False
         self.early_apply = event.shift
+
+        self.extend_mouse_values = get_preferences().enable_mouse_values and get_preferences().extend_mouse_values
 
         self.segments = 1
         self.weight = 1
@@ -417,7 +425,7 @@ def draw_text_callback(self):
     draw_property(
         self,
         "Segments: {}".format(self.segments),
-        self.generate_key_hint("Alt", self.generate_step_hint(2, 1)),
+        self.generate_key_hint("Alt / Scroll" if self.extend_mouse_values else "Alt", self.generate_step_hint(2, 1)),
         active=self.key_alt,
         alt_mode=self.key_shift_alt,
         mouse_value=True,

--- a/bevels/edge_bevel.py
+++ b/bevels/edge_bevel.py
@@ -191,8 +191,6 @@ CTRL — Remove existing modifiers"""
         self.dirty = False
         self.early_apply = event.shift
 
-        self.extend_mouse_values = get_preferences().enable_mouse_values and get_preferences().extend_mouse_values
-
         self.segments = 1
         self.weight = 1
         self.width = 0.05 * self.unit_factor

--- a/bevels/vertex_bevel.py
+++ b/bevels/vertex_bevel.py
@@ -88,7 +88,10 @@ CTRL — Remove existing modifiers"""
             self.target_object.show_in_front = not self.target_object.show_in_front
 
         if self.key_step_up:
-            if no_stream(self.segments_input_stream) and self.key_alt:
+            if self.extend_mouse_values and no_stream(self.segments_input_stream) and self.key_no_modifiers:
+                self.segments = 2 if self.segments == 1 else self.segments + segment_factor
+                self.dirty = True
+            elif no_stream(self.segments_input_stream) and self.key_alt:
                 self.segments = 2 if self.segments == 1 else self.segments + segment_factor
                 self.dirty = True
             elif no_stream(self.profile_input_stream) and self.key_ctrl:
@@ -99,7 +102,10 @@ CTRL — Remove existing modifiers"""
                 self.dirty = True
 
         if self.key_step_down:
-            if no_stream(self.segments_input_stream) and self.key_alt:
+            if self.extend_mouse_values and no_stream(self.segments_input_stream) and self.key_no_modifiers:
+                self.segments = max(1, self.segments - segment_factor)
+                self.dirty = True
+            elif no_stream(self.segments_input_stream) and self.key_alt:
                 self.segments = max(1, self.segments - segment_factor)
                 self.dirty = True
             elif no_stream(self.profile_input_stream) and self.key_ctrl:
@@ -153,6 +159,8 @@ CTRL — Remove existing modifiers"""
 
         self.late_apply = event.shift
         self.edge_mode = event.alt
+
+        self.extend_mouse_values = get_preferences().enable_mouse_values and get_preferences().extend_mouse_values
 
         self.dirty = False
 
@@ -357,7 +365,7 @@ def draw_text_callback(self):
     draw_property(
         self,
         "Segments: {}".format(self.segments),
-        self.generate_key_hint("Alt", self.generate_step_hint(2, 1)),
+        self.generate_key_hint("Alt / Scroll" if self.extend_mouse_values else "Alt", self.generate_step_hint(2, 1)),
         active=self.key_alt,
         alt_mode=self.key_shift_alt,
         mouse_value=True,

--- a/bevels/vertex_bevel.py
+++ b/bevels/vertex_bevel.py
@@ -160,8 +160,6 @@ CTRL — Remove existing modifiers"""
         self.late_apply = event.shift
         self.edge_mode = event.alt
 
-        self.extend_mouse_values = get_preferences().enable_mouse_values and get_preferences().extend_mouse_values
-
         self.dirty = False
 
         self.segments = 1

--- a/lib/base_operator.py
+++ b/lib/base_operator.py
@@ -61,6 +61,8 @@ class BaseOperator(bpy.types.Operator):
         unit_increment_size = get_preferences().unit_increment_size
         self.unit_step_hint = self.generate_step_hint(f"{(self.unit_scale * unit_increment_size):.2f}{self.unit_suffix}", f"{(self.unit_scale * 0.1 * unit_increment_size):.2f}{self.unit_suffix}")
 
+        self.extend_mouse_values = get_preferences().enable_mouse_values and get_preferences().extend_mouse_values
+
         return self.do_invoke(context, event)
 
 


### PR DESCRIPTION
This PR adds an option (enabled by default) to extend mouse scroll wheel support. This will allow users to adjust the segments of a bevel, for instance, without having to hold down the ALT key, more closely mimicking Blender's built-in bevel operator.