### PR TITLE
Add option to lock overlay parameters on recall

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -161,6 +161,11 @@ class NDPreferences(AddonPreferences):
         default="RESET",
     )
 
+    lock_overlay_parameters_on_recall: BoolProperty(
+        name="Lock Overlay Parameters on Recall",
+        default=True,
+    )
+
     overlay_pinned: BoolProperty(
         name="Overlay Pinned",
         default=False,
@@ -526,6 +531,7 @@ class NDPreferences(AddonPreferences):
             ["unit_increment_size"],
             ["enable_quick_favourites"],
             ["lock_overlay_pinning"],
+            ["lock_overlay_parameters_on_recall"],
             ["enable_sidebar"],
             ["enable_axis_helper"],
             ["axis_base_thickness", "axis_active_thickness", "axis_inactive_opacity"]]

--- a/bevels/bevel.py
+++ b/bevels/bevel.py
@@ -32,7 +32,7 @@ from .. lib.base_operator import BaseOperator
 from .. lib.overlay import update_overlay, init_overlay, toggle_pin_overlay, toggle_operator_passthrough, register_draw_handler, unregister_draw_handler, draw_header, draw_property, draw_hint
 from .. lib.events import capture_modifier_keys, pressed
 from .. lib.preferences import get_preferences
-from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream
+from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, set_stream, has_stream
 from .. lib.modifiers import new_modifier, remove_modifiers_ending_with, add_smooth_by_angle, rectify_smooth_by_angle
 
 
@@ -263,6 +263,12 @@ SHIFT — Create a stacked bevel modifier"""
         self.loop_slide_prev = self.loop_slide = self.bevel.loop_slide
         self.clamp_overlap_prev = self.clamp_overlap = self.bevel.use_clamp_overlap
         self.angle_prev = self.angle = degrees(self.bevel.angle_limit)
+
+        if get_preferences().lock_overlay_parameters_on_recall:
+            self.segments_input_stream = set_stream(self.segments)
+            self.width_input_stream = set_stream(self.width)
+            self.profile_input_stream = set_stream(self.profile)
+            self.angle_input_stream = set_stream(self.angle)
 
 
     def add_smooth_shading(self, context):

--- a/bevels/edge_bevel.py
+++ b/bevels/edge_bevel.py
@@ -32,7 +32,7 @@ from .. lib.base_operator import BaseOperator
 from .. lib.overlay import update_overlay, init_overlay, toggle_pin_overlay, toggle_operator_passthrough, register_draw_handler, unregister_draw_handler, draw_header, draw_property, draw_hint
 from .. lib.events import capture_modifier_keys, pressed
 from .. lib.preferences import get_preferences
-from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream
+from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream, set_stream
 from .. lib.modifiers import new_modifier, remove_modifiers_ending_with, rectify_smooth_by_angle, add_smooth_by_angle
 
 
@@ -265,6 +265,12 @@ CTRL — Remove existing modifiers"""
         self.weight = self.edge_weight_average
         self.loop_slide_prev = self.loop_slide = self.bevel.loop_slide
         self.clamp_overlap_prev = self.clamp_overlap = self.bevel.use_clamp_overlap
+
+        if get_preferences().lock_overlay_parameters_on_recall:
+            self.segments_input_stream = set_stream(self.segments)
+            self.weight_input_stream = set_stream(self.weight)
+            self.width_input_stream = set_stream(self.width)
+            self.profile_input_stream = set_stream(self.profile)
 
 
     def add_smooth_shading(self, context):

--- a/bevels/vertex_bevel.py
+++ b/bevels/vertex_bevel.py
@@ -32,7 +32,7 @@ from .. lib.base_operator import BaseOperator
 from .. lib.overlay import update_overlay, init_overlay, toggle_pin_overlay, toggle_operator_passthrough, register_draw_handler, unregister_draw_handler, draw_header, draw_property, draw_hint
 from .. lib.events import capture_modifier_keys, pressed
 from .. lib.preferences import get_preferences
-from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream
+from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream, set_stream
 from .. lib.modifiers import new_modifier, remove_modifiers_ending_with, rectify_smooth_by_angle, add_smooth_by_angle
 
 
@@ -239,6 +239,11 @@ CTRL — Remove existing modifiers"""
         self.width_prev = self.width = self.bevel.width
         self.segments_prev = self.segments = self.bevel.segments
         self.profile_prev = self.profile = self.bevel.profile
+
+        if get_preferences().lock_overlay_parameters_on_recall:
+            self.segments_input_stream = set_stream(self.segments)
+            self.width_input_stream = set_stream(self.width)
+            self.profile_input_stream = set_stream(self.profile)
 
 
     def prepare_new_operator(self, context):

--- a/deform/lattice.py
+++ b/deform/lattice.py
@@ -33,7 +33,7 @@ from .. lib.events import capture_modifier_keys, pressed
 from .. lib.preferences import get_preferences
 from .. lib.collections import move_to_utils_collection, isolate_in_utils_collection, hide_utils_collection
 from .. lib.math import generate_bounding_box, v3_average
-from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream
+from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream, set_stream
 from .. lib.modifiers import new_modifier, remove_modifiers_ending_with, rectify_smooth_by_angle
 
 
@@ -258,6 +258,11 @@ CTRL — Remove existing modifiers"""
             self.lattice_points_v = self.lattice_points_v_prev = self.lattice_obj.data.points_v
             self.lattice_points_w = self.lattice_points_w_prev = self.lattice_obj.data.points_w
             self.interpolation_mode = self.interpolation_mode_prev = self.interpolation_modes.index(self.lattice_obj.data.interpolation_type_u)
+
+        if get_preferences().lock_overlay_parameters_on_recall:
+            self.lattice_points_u_input_stream = set_stream(self.lattice_points_u)
+            self.lattice_points_v_input_stream = set_stream(self.lattice_points_v)
+            self.lattice_points_w_input_stream = set_stream(self.lattice_points_w)
 
 
     def add_lattice_object(self, context):

--- a/deform/simple_deform.py
+++ b/deform/simple_deform.py
@@ -33,7 +33,7 @@ from .. lib.overlay import update_overlay, init_overlay, toggle_pin_overlay, tog
 from .. lib.events import capture_modifier_keys, pressed
 from .. lib.preferences import get_preferences
 from .. lib.axis import init_axis, register_axis_handler, unregister_axis_handler
-from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream
+from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream, set_stream
 from .. lib.modifiers import new_modifier, remove_modifiers_ending_with, rectify_smooth_by_angle
 
 
@@ -79,6 +79,10 @@ CTRL — Remove existing modifiers"""
 
         elif pressed(event, {'M'}):
             self.current_method = (self.current_method + 1) % len(self.methods)
+            self.angle_input_stream = new_stream()
+            self.factor_input_stream = new_stream()
+            self.factor = 0
+            self.angle = 0
             self.dirty = True
 
         elif pressed(event, {'A'}):
@@ -191,6 +195,10 @@ CTRL — Remove existing modifiers"""
         self.method_prev = self.current_method = self.methods.index(self.deform.deform_method)
         self.angle_prev = self.angle = degrees(self.deform.angle)
         self.factor_prev = self.factor = self.deform.factor
+
+        if get_preferences().lock_overlay_parameters_on_recall:
+            self.angle_input_stream = set_stream(self.angle)
+            self.factor_input_stream = set_stream(self.factor)
 
 
     def add_simple_deform_modifier(self, context):

--- a/extrusion/profile_extrude.py
+++ b/extrusion/profile_extrude.py
@@ -33,7 +33,7 @@ from .. lib.overlay import update_overlay, init_overlay, toggle_pin_overlay, tog
 from .. lib.events import capture_modifier_keys, pressed
 from .. lib.preferences import get_preferences
 from .. lib.axis import init_axis, register_axis_handler, unregister_axis_handler
-from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream
+from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream, set_stream
 from .. lib.modifiers import new_modifier, remove_modifiers_ending_with, rectify_smooth_by_angle, add_smooth_by_angle
 
 
@@ -195,6 +195,10 @@ CTRL — Remove existing modifiers"""
         self.weighting = self.calculate_existing_weighting()
         self.weighting_offset_strength_prev = self.weighting_offset.strength
         self.offset_prev = self.offset = self.displace.strength
+
+        if get_preferences().lock_overlay_parameters_on_recall:
+            self.extrusion_length_input_stream = set_stream(self.extrusion_length)
+            self.offset_input_stream = set_stream(self.offset)
 
 
     def calculate_weighting_offset_strength(self):

--- a/extrusion/screw.py
+++ b/extrusion/screw.py
@@ -33,7 +33,7 @@ from .. lib.overlay import update_overlay, init_overlay, toggle_pin_overlay, tog
 from .. lib.events import capture_modifier_keys, pressed
 from .. lib.preferences import get_preferences
 from .. lib.axis import init_axis, register_axis_handler, unregister_axis_handler
-from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream
+from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream, set_stream
 from .. lib.modifiers import new_modifier, remove_modifiers_ending_with, add_smooth_by_angle, rectify_smooth_by_angle
 
 
@@ -227,6 +227,11 @@ CTRL — Remove existing modifiers"""
         self.segments_prev = self.segments = self.screw.render_steps
         self.angle_prev = self.angle = degrees(self.screw.angle)
         self.flip_normals_prev = self.flip_normals = self.screw.use_normal_flip
+
+        if get_preferences().lock_overlay_parameters_on_recall:
+            self.offset_input_stream = set_stream(self.offset)
+            self.angle_input_stream = set_stream(self.angle)
+            self.segments_input_stream = set_stream(self.segments)
 
 
     def add_smooth_shading(self, context):

--- a/extrusion/solidify.py
+++ b/extrusion/solidify.py
@@ -32,7 +32,7 @@ from .. lib.base_operator import BaseOperator
 from .. lib.overlay import init_overlay, register_draw_handler, unregister_draw_handler, draw_header, draw_property, draw_hint
 from .. lib.events import capture_modifier_keys, pressed
 from .. lib.preferences import get_preferences, get_scene_unit_factor
-from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream
+from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream, set_stream
 from .. lib.modifiers import new_modifier, remove_modifiers_ending_with, rectify_smooth_by_angle, add_smooth_by_angle
 
 
@@ -180,6 +180,10 @@ CTRL — Remove existing modifiers"""
         self.weighting_prev = self.weighting = self.solidify.offset
         self.complex_mode_prev = self.complex_mode = (self.solidify.solidify_mode == 'NON_MANIFOLD')
         self.offset_prev = self.offset = self.displace.strength
+
+        if get_preferences().lock_overlay_parameters_on_recall:
+            self.thickness_input_stream = set_stream(self.thickness)
+            self.offset_input_stream = set_stream(self.offset)
 
 
     def add_smooth_shading(self, context):

--- a/lib/numeric_input.py
+++ b/lib/numeric_input.py
@@ -76,6 +76,10 @@ def update_stream(input_stream, type):
     return ok, value, raw
 
 
+def set_stream(value):
+    return True, value, str(value)
+
+
 def no_stream(input_stream):
     ok, value, raw = input_stream
 

--- a/lib/overlay.py
+++ b/lib/overlay.py
@@ -242,7 +242,7 @@ def draw_property(cls, property_content, metadata_content, active=False, alt_mod
 
     if is_value is not None:
         reset_behaviour = get_preferences().overlay_reset_key_behaviour
-        blf.draw(0, "Manual Override — [{}] to {}.".format(get_preferences().overlay_reset_key, "reset" if reset_behaviour == "RESET" else "unlock"))
+        blf.draw(0, "{} — [{}] to {}.".format(metadata_content, get_preferences().overlay_reset_key, "reset" if reset_behaviour == "RESET" else "unlock"))
     else:
         blf.draw(0, metadata_content)
 

--- a/replicate/array_cubed.py
+++ b/replicate/array_cubed.py
@@ -32,7 +32,7 @@ from .. lib.overlay import update_overlay, init_overlay, toggle_pin_overlay, tog
 from .. lib.events import capture_modifier_keys, pressed
 from .. lib.preferences import get_preferences
 from .. lib.axis import init_axis, register_axis_handler, unregister_axis_handler
-from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream
+from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream, set_stream
 from .. lib.modifiers import new_modifier, remove_modifiers_starting_with
 
 
@@ -219,6 +219,10 @@ CTRL — Remove existing modifiers"""
                     break
             self.axes_prev[axis] = [array, array.count, offset, array.use_relative_offset]
             self.axes[axis] = [array, array.count, offset, array.use_relative_offset]
+
+        if get_preferences().lock_overlay_parameters_on_recall:
+            self.count_streams = [set_stream(self.axes[0][IDX_COUNT]), set_stream(self.axes[1][IDX_COUNT]), set_stream(self.axes[2][IDX_COUNT])]
+            self.offset_streams = [set_stream(self.axes[0][IDX_OFFSET]), set_stream(self.axes[1][IDX_OFFSET]), set_stream(self.axes[2][IDX_OFFSET])]
 
 
     def add_array_modifier(self, context, name, axis):

--- a/replicate/circular_array.py
+++ b/replicate/circular_array.py
@@ -36,7 +36,7 @@ from .. lib.events import capture_modifier_keys, pressed
 from .. lib.collections import move_to_utils_collection, hide_utils_collection
 from .. lib.preferences import get_preferences
 from .. lib.objects import set_origin
-from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream
+from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream, set_stream
 from .. lib.modifiers import new_modifier, remove_modifiers_ending_with
 
 
@@ -268,6 +268,11 @@ CTRL — Remove existing modifiers"""
         self.displace_axis = self.displace_axis_prev = ['X', 'Y', 'Z'].index(self.displace.direction)
         self.count = self.count_prev = self.array.count
         self.offset = self.offset_prev = self.displace.strength
+
+        if get_preferences().lock_overlay_parameters_on_recall:
+            self.count_input_stream = set_stream(self.count)
+            self.angle_input_stream = set_stream(self.angle)
+            self.offset_input_stream = set_stream(self.offset)
 
 
     def add_array_modifier(self):

--- a/sketch/circularize.py
+++ b/sketch/circularize.py
@@ -32,7 +32,7 @@ from .. lib.base_operator import BaseOperator
 from .. lib.overlay import update_overlay, init_overlay, toggle_pin_overlay, toggle_operator_passthrough, register_draw_handler, unregister_draw_handler, draw_header, draw_property, draw_hint
 from .. lib.events import capture_modifier_keys, pressed
 from .. lib.preferences import get_preferences
-from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream
+from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream, set_stream
 from .. lib.modifiers import new_modifier, remove_modifiers_ending_with, rectify_smooth_by_angle, add_smooth_by_angle
 
 
@@ -139,6 +139,11 @@ class ND_OT_circularize(BaseOperator):
         self.bevel = mods[mod_bevel]
 
         self.segments_prev = self.segments = self.bevel.segments
+
+        if get_preferences().lock_overlay_parameters_on_recall:
+            self.segments_input_stream = set_stream(self.segments)
+            self.width_input_stream = set_stream(self.bevel.width)
+            self.profile_input_stream = set_stream(self.bevel.profile)
 
 
     def prepare_new_operator(self, context):

--- a/sketch/recon_poly.py
+++ b/sketch/recon_poly.py
@@ -33,7 +33,7 @@ from .. lib.overlay import update_overlay, init_overlay, toggle_pin_overlay, tog
 from .. lib.objects import add_single_vertex_object, align_object_to_3d_cursor
 from .. lib.events import capture_modifier_keys, pressed
 from .. lib.preferences import get_preferences
-from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream
+from .. lib.numeric_input import update_stream, no_stream, get_stream_value, new_stream, has_stream, set_stream
 from .. lib.modifiers import new_modifier
 
 
@@ -244,6 +244,11 @@ class ND_OT_recon_poly(BaseOperator):
             self.obj.rotation_euler.rotate_axis('Z', radians((360 / self.segments) / 2) * -1)
             self.rotation_snapshot = self.obj.rotation_euler.copy()
             self.obj.rotation_euler = self.rotation_prev
+
+        if get_preferences().lock_overlay_parameters_on_recall:
+            self.segments_input_stream = set_stream(self.segments)
+            self.inner_radius_input_stream = set_stream(self.inner_radius)
+            self.width_input_stream = set_stream(self.width)
 
 
     @classmethod


### PR DESCRIPTION
This PR adds the option (enabled by default) to lock overlay parameters on recall. This helps to avoid accidental parameter adjustment when an operator is recalled, especially when mouse values are enabled.