### PR TITLE
fix: preserve empties used by constraints in clean utils

### DIFF
--- a/scene/clean_utils.py
+++ b/scene/clean_utils.py
@@ -87,7 +87,6 @@ class ND_OT_clean_utils(bpy.types.Operator):
             for mod in remove_mods:
                 obj.modifiers.remove(mod)
 
-        for obj in all_scene_objects:
             for constraint in obj.constraints:
                 if hasattr(constraint, 'target') and constraint.target:
                     active_util_object_names.add(constraint.target.name)

--- a/scene/clean_utils.py
+++ b/scene/clean_utils.py
@@ -87,6 +87,11 @@ class ND_OT_clean_utils(bpy.types.Operator):
             for mod in remove_mods:
                 obj.modifiers.remove(mod)
 
+        for obj in all_scene_objects:
+            for constraint in obj.constraints:
+                if hasattr(constraint, 'target') and constraint.target:
+                    active_util_object_names.add(constraint.target.name)
+
         all_util_objects = get_all_util_objects()
         deleted_objects = []
 


### PR DESCRIPTION
## Summary

The clean utils operation now checks object constraints (not just modifiers) before removing empties. Previously, empties referenced by constraints like `CHILD_OF`, `TRACK_TO`, `COPY_LOCATION`, etc. would be removed because only modifier references (`BOOLEAN`, `ARRAY`, `MIRROR`, `LATTICE`) were tracked.

This adds a constraint scan pass that marks any empty referenced via a constraint's `target` property as active, preventing it from being deleted.

Fixes #197